### PR TITLE
Document building and flashing for a bootloaded Pinguino

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,14 @@
 # Makes for one change, instead of 10.
 TARGET = main
 MCU = 32MX440F256H
+MCU_LOWER = 32mx440f256h
 #MCU = 32MX270F256D
-OPTIMIZATION = -O1
+#MCU_LOWER = 32mx270f256d
+
+#BOOTLOADER = ""
+BOOTLOADER = _pinguino
+
+OPTIMIZATION = -Os
 CRYSTALFREQUENCY = 8000000L
 MIN_HEAP_SIZE = _min_heap_size=2048
 
@@ -28,9 +34,8 @@ SIZE = mipsel-elf-size
 
 # The rest from here should automatically discern the needed scipts
 
-
 MCU_XC = __$(strip $(MCU))__	# Convert to form used by xc.h. 
-MCU_ASM_FILE = p$(MCU).S		# Definitions have a p prefix, and .S suffix
+MCU_ASM_FILE = p$(MCU_LOWER).S		# Definitions have a p prefix, and .S suffix
 
 # Extract information about the family automatically.
 ifeq ($(findstring 32MM, $(MCU)), 32MM)
@@ -46,9 +51,7 @@ endif
 
 
 
-
-
-LDSCRIPTS = -T$(P32M_TOOLCHAIN_PATH)/proc/$(MCU)/procdefs.ld -T$(P32M_TOOLCHAIN_PATH)/ldscripts/$(LDSCRIPT_USED)
+LDSCRIPTS = -T$(P32M_TOOLCHAIN_PATH)/proc/$(MCU)/procdefs$(BOOTLOADER).ld -T$(P32M_TOOLCHAIN_PATH)/ldscripts/$(LDSCRIPT_USED)
 STARTUPSCRIPTS = $(P32M_TOOLCHAIN_PATH)/libpic32/startup/crt0.S $(P32M_TOOLCHAIN_PATH)/libpic32/startup/general-exception.S
 INTERRUPTSCRIPT = $(P32M_TOOLCHAIN_PATH)/include/support/interrupt/interrupt.S	# The new isrwrapper/interrupt system
 # Added build dir to LDFLAGS, so xc.h can find processor.o
@@ -80,7 +83,8 @@ flash:
 	$(PIC32PROG_PATH)/pic32prog $(BUILD_DIR)/$(TARGET).hex -D -S -s 8000
 
 flash_icsp:
-	$(PIC32PROG_PATH)/pic32prog $(BUILD_DIR)/$(TARGET).hex -D -S -i ICSP -s 8000
+	$(PIC32PROG_PATH)/pic32prog $(BUILD_DIR)/$(TARGET).hex -D -S -i ICSP -
+s 8000
 
 
 # For debug, recursively call the makefile again, with the DEBUG varible

--- a/README.md
+++ b/README.md
@@ -19,6 +19,18 @@ The USB code works on both chips above. Currently implemented is a very basic US
 
 Schematics and connections to be added as project progresses.
 
-### FYI
+### Building
 
-The Makefile currently expects the .S files to be uppercase, while the toolchain has them in lowercase.
+To select the build configuration, look into the `Makefile`, and select the variables based on your MCU: `MCU` and `MCU_LOWER`. Select the `BOOTLOADER` variable appropriately.
+
+To build in your environment:
+
+```
+P32M_TOOLCHAIN_PATH=path/to/pic32-parts-free make
+```
+
+This will result in a file called `build/main.hex`. Flash it using pic32prog, and make sure that the directory with pic32prog is in your `$PATH`. If using a USB boot loader, the call is rather simple:
+
+```
+pic32prog build/main.hex
+```


### PR DESCRIPTION
Like it says in the title.

While doing this, I've (re)discovered that Make is quite terrible when you need to support several different configurations even worse when they are needed alongside each other (debug/normal/different device), and also useless when dealing with tasks that don't produce files (like flashing, which can also be done in several ways).

I decided to ignore this even if it's annoying me to no end :)

Anyway, this let me have the Pinguino become a working USB device.